### PR TITLE
Use a config in root directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "operator-repo"
-version = "0.2.0"
+version = "0.3.0"
 description = "Library and utilities to handle repositories of kubernetes operators"
 authors = [
     {name = "Maurizio Porrato", email = "mporrato@redhat.com"},
@@ -48,7 +48,18 @@ ignore-patterns = ["^\\.#"]
 no-docstring-rgx = "^(test)?_"
 
 [tool.pylint."messages control"]
-disable = ["raw-checker-failed", "bad-inline-option", "locally-disabled", "file-ignored", "suppressed-message", "useless-suppression", "deprecated-pragma", "use-symbolic-message-instead", "missing-module-docstring", "missing-function-docstring"]
+disable = [
+    "raw-checker-failed",
+    "bad-inline-option",
+    "locally-disabled",
+    "file-ignored",
+    "suppressed-message",
+    "useless-suppression",
+    "deprecated-pragma",
+    "use-symbolic-message-instead",
+    "missing-module-docstring",
+    "missing-function-docstring",
+]
 enable = ["c-extension-no-member"]
 
 [tool.pylint.variables]
@@ -59,6 +70,6 @@ exclude_dirs = ["tests", ".tox", ".venv"]
 
 [tool.autoflake]
 recursive = true
-remove-all-unused-imports=true
+remove-all-unused-imports = true
 remove-duplicate-keys = true
 remove-unused-variables = true

--- a/src/operator_repo/core.py
+++ b/src/operator_repo/core.py
@@ -493,12 +493,12 @@ class Repo:
     @cached_property
     def config(self) -> Any:
         """
-        :return: The contents of the ci/pipeline-config.yaml for the repo
+        :return: The contents of the config.yaml for the repo
         """
         try:
-            return load_yaml(self._repo_path / "ci" / "pipeline-config.yaml")
+            return load_yaml(self._repo_path / "config.yaml")
         except FileNotFoundError:
-            log.warning("No ci/pipeline-config.yaml found for %s", self)
+            log.warning("No config.yaml found for %s", self)
             return {}
 
     @classmethod

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -22,7 +22,7 @@ def test_repo_no_operators(tmp_path: Path) -> None:
         tmp_path,
         {
             "operators": None,
-            "ci/pipeline-config.yaml": {"hello": "world"},
+            "config.yaml": {"hello": "world"},
         },
     )
     repo = Repo(tmp_path)


### PR DESCRIPTION
The config.yaml in root directory in the main config for a whole repository. The previous path was pointing to a legacy location.