### PR TITLE
Add Catalog and CatalogOperator structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "operator-repo"
-version = "0.3.0"
+version = "0.4.0"
 description = "Library and utilities to handle repositories of kubernetes operators"
 authors = [
     {name = "Maurizio Porrato", email = "mporrato@redhat.com"},

--- a/src/operator_repo/__init__.py
+++ b/src/operator_repo/__init__.py
@@ -1,3 +1,3 @@
-from .core import Bundle, Operator, Repo
+from .core import Bundle, Catalog, Operator, OperatorCatalog, Repo
 
-__all__ = ["Repo", "Operator", "Bundle"]
+__all__ = ["Repo", "Operator", "Bundle", "Catalog", "OperatorCatalog"]

--- a/src/operator_repo/exceptions.py
+++ b/src/operator_repo/exceptions.py
@@ -17,3 +17,11 @@ class InvalidOperatorException(OperatorRepoException):
 
 class InvalidBundleException(OperatorRepoException):
     """Error caused by an invalid bundle"""
+
+
+class InvalidCatalogException(OperatorRepoException):
+    """Error caused by an invalid catalog"""
+
+
+class InvalidOperatorCatalogException(OperatorRepoException):
+    """Error caused by an invalid operator catalog"""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -90,6 +90,19 @@ def create_files(path: Union[str, Path], *contents: dict[str, Any]) -> None:
                     full_path.write_text(yaml.safe_dump(content))
 
 
+def catalog_files(
+    catalog_name: str, operator: str, other_files: Optional[dict[str, Any]] = None
+) -> dict[str, Any]:
+    operator_path = f"catalogs/{catalog_name}/{operator}"
+
+    return merge(
+        {
+            f"{operator_path}/catalog.yaml": {"foo": "bar"},
+        },
+        other_files or {},
+    )
+
+
 def bundle_files(
     operator_name: str,
     bundle_version: str,

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+import pytest
+
+from operator_repo import Catalog, Repo
+from operator_repo.exceptions import InvalidCatalogException
+from tests import bundle_files, catalog_files, create_files
+
+
+def test_no_catalog(tmp_path: Path) -> None:
+    create_files(tmp_path, bundle_files("fake-operator", "0.0.1"))
+    repo = Repo(tmp_path)
+    assert list(repo.all_catalogs()) == []
+
+
+def test_invalid_catalog(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        catalog_files("v4.14", "fake-operator"),
+        bundle_files("fake-operator", "0.0.1"),
+    )
+    repo = Repo(tmp_path)
+    with pytest.raises(InvalidCatalogException):
+        Catalog(repo.root / "catalogs" / "not-found")
+
+
+def test_catalog_empty(tmp_path: Path) -> None:
+    create_files(
+        tmp_path, {"catalogs/readme.txt": "hello", "operators/readme.txt": "hello"}
+    )
+    repo = Repo(tmp_path)
+    assert not repo.has_catalog("hello")
+
+
+def test_catalog_one_operator(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        catalog_files("v4.14", "fake-operator"),
+        bundle_files("fake-operator", "0.0.1"),
+        {"catalogs/readme.txt": "hello"},
+    )
+    repo = Repo(tmp_path)
+    assert list(repo.all_catalogs()) == [repo.catalog("v4.14")]
+    catalog = repo.catalog("v4.14")
+    assert repr(catalog) == "Catalog(v4.14)"
+    assert catalog.repo == repo
+    assert Catalog(catalog.root).repo == repo
+    operator = catalog.operator_catalog("fake-operator")
+    assert len(list(catalog)) == 1
+    assert set(catalog) == {operator}
+    assert not catalog.has("not-found")
+    assert catalog.has("fake-operator")
+
+
+def test_catalog_compare(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        catalog_files("v4.14", "fake-operator"),
+        catalog_files("v4.14", "fake-operator-2"),
+        catalog_files("v4.15", "fake-operator-2"),
+        bundle_files("fake-operator", "0.0.1"),
+    )
+    repo = Repo(tmp_path)
+
+    assert repo.catalog("v4.14") == repo.catalog("v4.14")
+    assert repo.catalog("v4.14") != repo.catalog("v4.15")
+    assert repo.catalog("v4.14") < repo.catalog("v4.15")
+    assert repo.catalog("v4.14") != {"foo": "bar"}
+    with pytest.raises(TypeError):
+        repo.catalog("v4.14") < {"foo": "bar"}

--- a/tests/test_operator_catalog.py
+++ b/tests/test_operator_catalog.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+import pytest
+
+from operator_repo import OperatorCatalog, Repo
+from operator_repo.exceptions import InvalidOperatorCatalogException
+from tests import bundle_files, catalog_files, create_files
+
+
+def test_invalid_catalog(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        catalog_files("v4.14", "fake-operator"),
+        bundle_files("fake-operator", "0.0.1"),
+    )
+    repo = Repo(tmp_path)
+    with pytest.raises(InvalidOperatorCatalogException):
+        OperatorCatalog(repo.root / "catalogs" / "4.14" / "not-found")
+
+
+def test_operator_catalog(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        catalog_files("v4.14", "fake-operator"),
+        bundle_files("fake-operator", "0.0.1"),
+    )
+    repo = Repo(tmp_path)
+    catalog = repo.catalog("v4.14")
+    assert len(list(catalog.all_operator_catalogs())) == 1
+    operator = catalog.operator_catalog("fake-operator")
+
+    assert repr(operator) == "OperatorCatalog(fake-operator)"
+
+    assert operator.repo == repo
+    assert operator.catalog == catalog
+
+    assert operator.catalog_content_path == operator.root / "catalog.yaml"
+
+    assert operator == catalog.operator_catalog("fake-operator")
+
+    operator = OperatorCatalog(operator.root)
+    assert operator.catalog == catalog
+
+
+def test_catalog_operator_compare(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        catalog_files("v4.14", "fake-operator"),
+        catalog_files("v4.14", "fake-operator-2"),
+        bundle_files("fake-operator", "0.0.1"),
+    )
+    repo = Repo(tmp_path)
+    catalog = repo.catalog("v4.14")
+    operator1 = catalog.operator_catalog("fake-operator")
+    operator2 = catalog.operator_catalog("fake-operator-2")
+
+    assert operator1 == operator1
+    assert operator1 != operator2
+    assert operator1 < operator2
+
+    assert operator1 != "foo"
+    with pytest.raises(TypeError):
+        operator1 < "foo"

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -4,7 +4,7 @@ import pytest
 
 from operator_repo import Repo
 from operator_repo.exceptions import InvalidRepoException
-from tests import bundle_files, create_files
+from tests import bundle_files, catalog_files, create_files
 
 
 def test_repo_non_existent() -> None:
@@ -33,10 +33,13 @@ def test_repo_no_operators(tmp_path: Path) -> None:
 
 
 def test_repo_one_bundle(tmp_path: Path) -> None:
-    create_files(tmp_path, bundle_files("hello", "0.0.1"))
+    create_files(
+        tmp_path, bundle_files("hello", "0.0.1"), catalog_files("v4.14", "hello")
+    )
     repo = Repo(tmp_path)
     assert repo.config == {}
     assert len(list(repo)) == 1
     assert set(repo) == {repo.operator("hello")}
     assert repo.has("hello")
     assert repo != "foo"
+    assert repo.has_catalog("v4.14")


### PR DESCRIPTION
The Catalog and CatalogOperator are new classes introduced in this commit that represents a repo structure given by File-Based-Catalog.

Each Catalog has a set of Operators and their FBCs.

JIRA: ISV-4491