### PR TITLE
Add link between catalog and operator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "operator-repo"
-version = "0.4.0"
+version = "0.4.1"
 description = "Library and utilities to handle repositories of kubernetes operators"
 authors = [
     {name = "Maurizio Porrato", email = "mporrato@redhat.com"},

--- a/src/operator_repo/core.py
+++ b/src/operator_repo/core.py
@@ -288,6 +288,14 @@ class Operator:
             self._parent = Repo(self._operator_path.parent.parent)
         return self._parent
 
+    def all_catalogs(self) -> Iterator["Catalog"]:
+        """
+        :return: All the catalogs containing the operator
+        """
+        for catalog in self.repo.all_catalogs():
+            if catalog.has(self.operator_name):
+                yield catalog
+
     def all_bundles(self) -> Iterator[Bundle]:
         """
         :return: All the bundles for the operator
@@ -528,6 +536,13 @@ class OperatorCatalog:
         if self._parent is None:
             self._parent = Catalog(self._operator_catalog_path.parent)
         return self._parent
+
+    @property
+    def operator(self) -> "Operator":
+        """
+        :return: The Operator object the operator catalog belongs to
+        """
+        return self.repo.operator(self.operator_name)
 
     @property
     def catalog_content_path(

--- a/tests/test_operator_catalog.py
+++ b/tests/test_operator_catalog.py
@@ -22,24 +22,31 @@ def test_operator_catalog(tmp_path: Path) -> None:
     create_files(
         tmp_path,
         catalog_files("v4.14", "fake-operator"),
+        catalog_files("v4.13", "fake-operator-2"),
         bundle_files("fake-operator", "0.0.1"),
     )
     repo = Repo(tmp_path)
     catalog = repo.catalog("v4.14")
     assert len(list(catalog.all_operator_catalogs())) == 1
-    operator = catalog.operator_catalog("fake-operator")
+    operator_catalog = catalog.operator_catalog("fake-operator")
 
-    assert repr(operator) == "OperatorCatalog(fake-operator)"
+    assert repr(operator_catalog) == "OperatorCatalog(fake-operator)"
 
-    assert operator.repo == repo
-    assert operator.catalog == catalog
+    assert operator_catalog.repo == repo
+    assert operator_catalog.catalog == catalog
 
-    assert operator.catalog_content_path == operator.root / "catalog.yaml"
+    assert (
+        operator_catalog.catalog_content_path == operator_catalog.root / "catalog.yaml"
+    )
 
-    assert operator == catalog.operator_catalog("fake-operator")
+    assert operator_catalog == catalog.operator_catalog("fake-operator")
 
-    operator = OperatorCatalog(operator.root)
-    assert operator.catalog == catalog
+    operator_catalog = OperatorCatalog(operator_catalog.root)
+    assert operator_catalog.catalog == catalog
+
+    assert operator_catalog.operator == repo.operator("fake-operator")
+
+    assert list(repo.operator("fake-operator").all_catalogs()) == [catalog]
 
 
 def test_catalog_operator_compare(tmp_path: Path) -> None:


### PR DESCRIPTION
If a catalog contains given operator a new link from the catalog to operator becomes available. The link also works in the opposite direction and we can get from operator into list of all catalog where the operator is present.