### PR TITLE
Fix: Operator probe supports empty operator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "operator-repo"
-version = "0.4.1"
+version = "0.4.2"
 description = "Library and utilities to handle repositories of kubernetes operators"
 authors = [
     {name = "Maurizio Porrato", email = "mporrato@redhat.com"},

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -12,6 +12,14 @@ def test_operator_empty(tmp_path: Path) -> None:
     assert not repo.has("hello")
 
 
+def test_operator_no_bundles(tmp_path: Path) -> None:
+    create_files(tmp_path, {"operators/hello/ci.yaml": "hello"})
+    repo = Repo(tmp_path)
+    assert repo.has("hello")
+
+    assert repo.operator("hello").head("beta") is None
+
+
 def test_operator_one_bundle(tmp_path: Path) -> None:
     create_files(tmp_path, bundle_files("hello", "0.0.1"))
     repo = Repo(tmp_path)


### PR DESCRIPTION
In case there is no bundle inside the operator BUT the ci.yaml file is available the library consider this as a valid operator path.