### PR TITLE
Relax update graph checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "operator-repo"
-version = "0.4.2"
+version = "0.4.3"
 description = "Library and utilities to handle repositories of kubernetes operators"
 authors = [
     {name = "Maurizio Porrato", email = "mporrato@redhat.com"},

--- a/src/operator_repo/checks/bundle.py
+++ b/src/operator_repo/checks/bundle.py
@@ -7,24 +7,78 @@ from ..utils import lookup_dict
 from . import CheckResult, Fail, Warn
 
 
+def _check_consistency(
+    my_name: str, all_names: set[str], other_names: set[str], result_description: str
+) -> Iterator[CheckResult]:
+    """Helper function for check_operator_name"""
+    if len(other_names) == 1:
+        # Operator names are consistent across other bundles
+        common_name = other_names.pop()
+        if common_name != my_name:
+            # The new bundle has a different operator name
+            msg = (
+                f"Operator name {result_description} ({my_name})"
+                f" does not match the name defined in other"
+                f" bundles ({common_name})"
+            )
+            yield Fail(msg)
+    else:
+        # Other bundles have inconsistent operator names: let's just issue a warning
+        msg = (
+            f"Operator name {result_description} is not consistent across bundles:"
+            f" {sorted(all_names)}"
+        )
+        yield Warn(msg)
+
+
 def check_operator_name(bundle: Bundle) -> Iterator[CheckResult]:
-    """Check if the operator names used in CSV, metadata and filesystem are consistent"""
-    name = bundle.annotations.get("operators.operatorframework.io.bundle.package.v1")
-    if name is None:
+    """Check if the operator names used in CSV, metadata and filesystem are consistent
+    in the bundle and across other operator's bundles"""
+    if not bundle.metadata_operator_name:
         yield Fail("Bundle does not define the operator name in annotations.yaml")
         return
-    if name != bundle.csv_operator_name:
+    all_bundles = set(bundle.operator.all_bundles())
+    all_metadata_operator_names = {x.metadata_operator_name for x in all_bundles}
+    all_csv_operator_names = {x.csv_operator_name for x in all_bundles}
+    other_bundles = all_bundles - {bundle}
+    other_metadata_operator_names = {x.metadata_operator_name for x in other_bundles}
+    other_csv_operator_names = {x.csv_operator_name for x in other_bundles}
+    # Count how many unique names are in use in the CSV and annotations.yaml across
+    # all other bundles. Naming is consistent if the count is zero (when the bundle
+    # under test is the only bundle for its operator) or one
+    consistent_metadata_names = len(other_metadata_operator_names) < 2
+    consistent_csv_names = len(other_csv_operator_names) < 2
+    if other_bundles:
+        yield from _check_consistency(
+            bundle.metadata_operator_name,
+            all_metadata_operator_names,
+            other_metadata_operator_names,
+            "from annotations.yaml",
+        )
+        yield from _check_consistency(
+            bundle.csv_operator_name,
+            all_csv_operator_names,
+            other_csv_operator_names,
+            "from the CSV",
+        )
+    if bundle.metadata_operator_name != bundle.csv_operator_name:
         msg = (
-            f"Operator name from annotations.yaml ({name})"
+            f"Operator name from annotations.yaml ({bundle.metadata_operator_name})"
             f" does not match the name defined in the CSV ({bundle.csv_operator_name})"
         )
-        yield Fail(msg)
-    if name != bundle.operator_name:
+        if consistent_metadata_names and consistent_csv_names:
+            yield Fail(msg)
+        else:
+            yield Warn(msg)
+    if bundle.metadata_operator_name != bundle.operator_name:
         msg = (
-            f"Operator name from annotations.yaml ({name})"
+            f"Operator name from annotations.yaml ({bundle.metadata_operator_name})"
             f" does not match the operator's directory name ({bundle.operator_name})"
         )
-        yield Fail(msg)
+        if consistent_metadata_names:
+            yield Fail(msg)
+        else:
+            yield Warn(msg)
 
 
 def check_image(bundle: Bundle) -> Iterator[CheckResult]:

--- a/src/operator_repo/core.py
+++ b/src/operator_repo/core.py
@@ -423,14 +423,7 @@ class Operator:
                     raise ValueError(
                         f"{bundle} has invalid 'replaces' field: '{replaced_bundle_name}'"
                     )
-                (
-                    replaced_bundle_operator,
-                    replaced_bundle_version,
-                ) = replaced_bundle_name.split(".", 1)
-                if replaced_bundle_operator != bundle.csv_operator_name:
-                    raise ValueError(
-                        f"{bundle} replaces a bundle from a different operator"
-                    )
+                replaced_bundle_version = replaced_bundle_name.split(".", 1)[1]
                 try:
                     replaced_bundle = version_to_bundle[
                         replaced_bundle_version.lstrip("v")
@@ -453,11 +446,6 @@ class Operator:
         """
         all_bundles = self.channel_bundles(channel)
         update_strategy = self.config.get("updateGraph", "replaces-mode")
-        operator_names = {x.csv_operator_name for x in all_bundles}
-        if len(operator_names) > 1:
-            raise ValueError(
-                f"{self} has bundles with different operator names: {operator_names}"
-            )
         if update_strategy == "semver-mode":
             return {x: {y} for x, y in zip(all_bundles, all_bundles[1:])}
         if update_strategy == "replaces-mode":

--- a/src/operator_repo/core.py
+++ b/src/operator_repo/core.py
@@ -69,6 +69,15 @@ class Bundle:
             raise InvalidBundleException(f"Invalid CSV contents ({self.csv_file_name})")
         return csv
 
+    @property
+    def metadata_operator_name(self) -> str:
+        """
+        :return: The operator name as defined in the annotations file
+        """
+        return str(
+            self.annotations.get("operators.operatorframework.io.bundle.package.v1", "")
+        )
+
     @cached_property
     def csv_full_name(self) -> tuple[str, str]:
         """

--- a/tests/checks/test_bundle.py
+++ b/tests/checks/test_bundle.py
@@ -4,52 +4,204 @@ from typing import Any, Union
 import pytest
 
 from operator_repo import Repo
+from operator_repo.checks import Fail, Warn
 from operator_repo.checks.bundle import check_image, check_operator_name, check_semver
 from tests import bundle_files, create_files, make_nested_dict
 
 
 @pytest.mark.parametrize(
-    "base_bundle_files, extra_files, expected_results",
+    "files, bundle_to_check, expected_results",
     [
         (
-            bundle_files("hello", "0.0.1"),
-            {},
+            [
+                bundle_files("hello", "0.0.1"),
+            ],
+            ("hello", "0.0.1"),
             set(),
         ),
         (
-            bundle_files(
-                "hello",
-                "0.0.1",
-                annotations={"operators.operatorframework.io.bundle.package.v1": "foo"},
-            ),
-            {},
+            [
+                bundle_files(
+                    "hello",
+                    "0.0.1",
+                    annotations={
+                        "operators.operatorframework.io.bundle.package.v1": "foo"
+                    },
+                ),
+            ],
+            ("hello", "0.0.1"),
             {
-                "Operator name from annotations.yaml (foo) does not match the operator's directory name (hello)",
-                "Operator name from annotations.yaml (foo) does not match the name defined in the CSV (hello)",
+                (
+                    Fail,
+                    "Operator name from annotations.yaml (foo) does not match"
+                    " the operator's directory name (hello)",
+                ),
+                (
+                    Fail,
+                    "Operator name from annotations.yaml (foo) does not match"
+                    " the name defined in the CSV (hello)",
+                ),
             },
         ),
         (
-            bundle_files("hello", "0.0.1"),
-            {"operators/hello/0.0.1/metadata/annotations.yaml": {"annotations": {}}},
+            [
+                bundle_files("hello", "0.0.1"),
+                {
+                    "operators/hello/0.0.1/metadata/annotations.yaml": {
+                        "annotations": {}
+                    }
+                },
+            ],
+            ("hello", "0.0.1"),
             {
-                "Bundle does not define the operator name in annotations.yaml",
+                (Fail, "Bundle does not define the operator name in annotations.yaml"),
+            },
+        ),
+        (
+            [
+                bundle_files("hello", "0.0.1"),
+                bundle_files(
+                    "hello",
+                    "0.0.2",
+                    annotations={
+                        "operators.operatorframework.io.bundle.package.v1": "foo"
+                    },
+                ),
+                bundle_files(
+                    "hello",
+                    "0.0.3",
+                    annotations={
+                        "operators.operatorframework.io.bundle.package.v1": "foo"
+                    },
+                ),
+            ],
+            ("hello", "0.0.3"),
+            {
+                (
+                    Warn,
+                    "Operator name from annotations.yaml (foo) does not match"
+                    " the operator's directory name (hello)",
+                ),
+                (
+                    Warn,
+                    "Operator name from annotations.yaml (foo) does not match"
+                    " the name defined in the CSV (hello)",
+                ),
+                (
+                    Warn,
+                    "Operator name from annotations.yaml is not consistent"
+                    " across bundles: ['foo', 'hello']",
+                ),
+            },
+        ),
+        (
+            [
+                bundle_files("hello", "0.0.1"),
+                bundle_files(
+                    "hello",
+                    "0.0.2",
+                    csv={"metadata": {"name": "foo.v0.0.2"}},
+                ),
+                bundle_files(
+                    "hello",
+                    "0.0.3",
+                    csv={"metadata": {"name": "foo.v0.0.3"}},
+                ),
+            ],
+            ("hello", "0.0.3"),
+            {
+                (
+                    Warn,
+                    "Operator name from annotations.yaml (hello) does not match"
+                    " the name defined in the CSV (foo)",
+                ),
+                (
+                    Warn,
+                    "Operator name from the CSV is not consistent across bundles: ['foo', 'hello']",
+                ),
+            },
+        ),
+        (
+            [
+                bundle_files("hello", "0.0.1"),
+                bundle_files("hello", "0.0.2"),
+                bundle_files(
+                    "hello",
+                    "0.0.3",
+                    annotations={
+                        "operators.operatorframework.io.bundle.package.v1": "foo"
+                    },
+                ),
+            ],
+            ("hello", "0.0.3"),
+            {
+                (
+                    Fail,
+                    "Operator name from annotations.yaml (foo) does not match"
+                    " the operator's directory name (hello)",
+                ),
+                (
+                    Fail,
+                    "Operator name from annotations.yaml (foo) does not match"
+                    " the name defined in the CSV (hello)",
+                ),
+                (
+                    Fail,
+                    "Operator name from annotations.yaml (foo) does not match"
+                    " the name defined in other bundles (hello)",
+                ),
+            },
+        ),
+        (
+            [
+                bundle_files("hello", "0.0.1"),
+                bundle_files("hello", "0.0.2"),
+                bundle_files(
+                    "hello",
+                    "0.0.3",
+                    csv={"metadata": {"name": "foo.v0.0.3"}},
+                ),
+            ],
+            ("hello", "0.0.3"),
+            {
+                (
+                    Fail,
+                    "Operator name from annotations.yaml (hello) does not match"
+                    " the name defined in the CSV (foo)",
+                ),
+                (
+                    Fail,
+                    "Operator name from the CSV (foo) does not match the name"
+                    " defined in other bundles (hello)",
+                ),
             },
         ),
     ],
     indirect=False,
-    ids=["Names ok", "Wrong annotations.yaml", "Empty annotations.yaml"],
+    ids=[
+        "Names ok",
+        "Wrong annotations.yaml name",
+        "Empty annotations.yaml",
+        "Wrong annotations.yaml name, inconsistent bundles",
+        "Wrong CSV name, inconsistent bundles",
+        "Wrong annotations.yaml name, consistent bundles",
+        "Wrong CSV name, consistent bundles",
+    ],
 )
 def test_operator_name(
     tmp_path: Path,
-    base_bundle_files: dict[str, Any],
-    extra_files: dict[str, Any],
-    expected_results: set[str],
+    files: list[dict[str, Any]],
+    bundle_to_check: tuple[str, str],
+    expected_results: set[tuple[type, str]],
 ) -> None:
-    create_files(tmp_path, base_bundle_files, extra_files)
+    create_files(tmp_path, *files)
     repo = Repo(tmp_path)
-    operator = next(repo.all_operators())
-    bundle = next(operator.all_bundles())
-    assert {x.reason for x in check_operator_name(bundle)} == expected_results
+    operator_name, bundle_version = bundle_to_check
+    operator = repo.operator(operator_name)
+    bundle = operator.bundle(bundle_version)
+    assert {
+        (x.__class__, x.reason) for x in check_operator_name(bundle)
+    } == expected_results
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Ignore the operator name when building the update graph
- Update the check_operator_name to return hard fails only when the bundle being tested has an operator name inconsistent with all other bundles and only issue warnings if the operator name is generally inconsistent across other bundles