### PR TITLE
[ISV-5446] update FBC workflow with catalog retrieval

### DIFF
--- a/src/operator_repo/cli.py
+++ b/src/operator_repo/cli.py
@@ -43,6 +43,9 @@ def show_operator(operator: Operator, recursive: bool = False, depth: int = 0) -
             show_bundle(bundle, depth + 1)
         else:
             print(indent(depth + 1) + str(bundle))
+    # list also the operator catalogs if exist
+    for operator_catalog in operator.all_operator_catalogs():
+        print(indent(depth + 1) + str(operator_catalog))
 
 
 def show_bundle(bundle: Bundle, depth: int = 0) -> None:

--- a/src/operator_repo/utils.py
+++ b/src/operator_repo/utils.py
@@ -4,7 +4,7 @@
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 import yaml
 from yaml.composer import ComposerError
@@ -110,7 +110,7 @@ def load_yaml(path: Path) -> Any:
     return _load_yaml_strict(_find_yaml(path))
 
 
-def _load_multidoc_yaml_strict(path: Path) -> List[Dict[str, Any]]:
+def _load_multidoc_yaml_strict(path: Path) -> list[Any]:
     """
     Load and parse the content of a multi-doc YAML file at the given path.
 
@@ -122,7 +122,7 @@ def _load_multidoc_yaml_strict(path: Path) -> List[Dict[str, Any]]:
         path (Path): The path to the YAML file to be loaded.
 
     Returns:
-        list[dict[str, Any]]: The parsed contents of the multi-doc YAML file.
+        list[Any]: The parsed contents of the multi-doc YAML file.
 
     Raises:
         OperatorRepoException: If the YAML file is not a valid YAML document.
@@ -140,7 +140,7 @@ def _load_multidoc_yaml_strict(path: Path) -> List[Dict[str, Any]]:
             raise OperatorRepoException(f"{path} is not a valid yaml document") from exc
 
 
-def load_multidoc_yaml(path: Path) -> List[Dict[str, Any]]:
+def load_multidoc_yaml(path: Path) -> list[dict[str, Any]]:
     """
     Load and parse the contents of a YAML file at the given path.
 
@@ -148,7 +148,10 @@ def load_multidoc_yaml(path: Path) -> List[Dict[str, Any]]:
         path (Path): The path to the file with or without a YAML extension.
 
     Returns:
-        list[dict[str, Any]]: The parsed contents of the YAML file.
+        list[Any]: The parsed contents of the YAML file. Each element in the list
+            represents a document in the multi-doc YAML file. Be aware that the
+            elements are not guaranteed to be specific types. They can be any valid
+            YAML document - a dictionary, a list, a string, etc.
 
     Raises:
         OperatorRepoException: If the YAML file is not a valid YAML document.

--- a/src/operator_repo/utils.py
+++ b/src/operator_repo/utils.py
@@ -4,7 +4,7 @@
 
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List
 
 import yaml
 from yaml.composer import ComposerError
@@ -108,6 +108,58 @@ def load_yaml(path: Path) -> Any:
         # will be stored in the `yaml_content` variable.
     """
     return _load_yaml_strict(_find_yaml(path))
+
+
+def _load_multidoc_yaml_strict(path: Path) -> List[Dict[str, Any]]:
+    """
+    Load and parse the content of a multi-doc YAML file at the given path.
+
+    This function reads the contents of the specified YAML file and attempts to parse it
+    using the `yaml.safe_load_all` method. If the YAML document is not a valid
+    YAML document, exceptions is raised.
+
+    Args:
+        path (Path): The path to the YAML file to be loaded.
+
+    Returns:
+        list[dict[str, Any]]: The parsed contents of the multi-doc YAML file.
+
+    Raises:
+        OperatorRepoException: If the YAML file is not a valid YAML document.
+
+    Example:
+        yaml_path = Path("my_file.yaml")
+        yaml_content = _load_multidoc_yaml_strict(yaml_path)
+        # The parsed contents of the YAML file will be stored in the `yaml_content` variable.
+    """
+    log.debug("Loading %s", path)
+    with path.open("r") as yaml_file:
+        try:
+            return list(yaml.safe_load_all(yaml_file))
+        except ParserError as exc:
+            raise OperatorRepoException(f"{path} is not a valid yaml document") from exc
+
+
+def load_multidoc_yaml(path: Path) -> List[Dict[str, Any]]:
+    """
+    Load and parse the contents of a YAML file at the given path.
+
+    Args:
+        path (Path): The path to the file with or without a YAML extension.
+
+    Returns:
+        list[dict[str, Any]]: The parsed contents of the YAML file.
+
+    Raises:
+        OperatorRepoException: If the YAML file is not a valid YAML document.
+
+    Example:
+        file_path = Path("my_file.json")
+        yaml_content = load_yaml(file_path)
+        # If "my_file.yaml" or "my_file.yml" exists, the parsed contents of the YAML file
+        # will be stored in the `yaml_content` variable.
+    """
+    return _load_multidoc_yaml_strict(_find_yaml(path))
 
 
 def lookup_dict(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -58,6 +58,8 @@ def create_files(path: Union[str, Path], *contents: dict[str, Any]) -> None:
             For files, the dictionary should have a single key-value pair where the key is
             the filename and the value is the content of the file. For directories, the
             dictionary should have a single key with a value of None.
+            To create a multi-document yaml file, the content value should be a tuple.
+            Each value of the tuple will be a separate document in the resulting yaml file.
 
     Returns:
         None
@@ -68,11 +70,13 @@ def create_files(path: Union[str, Path], *contents: dict[str, Any]) -> None:
             {"file1.txt": "Hello, World!"},
             {"subfolder": None},
             {"config.yaml": {"key": "value"}},
+            {"catalog.yaml": ({"foo": "bar"}, {"baz": "qux"})}
         )
 
     In this example, the function will create a file "file1.txt" with content "Hello, World!"
-    in the "/my_folder" directory, create an empty subdirectory "subfolder", and create a
-    file "config.yaml" with the specified YAML content.
+    in the "/my_folder" directory, create an empty subdirectory "subfolder", create
+    a file "config.yaml" with the specified YAML content and create a multi-document YAML
+    file "catalog.yaml" with two documents.
     """
     root = Path(path)
     for element in contents:
@@ -86,7 +90,7 @@ def create_files(path: Union[str, Path], *contents: dict[str, Any]) -> None:
                     full_path.write_text(content)
                 elif isinstance(content, bytes):
                     full_path.write_bytes(content)
-                elif isinstance(content, list):
+                elif isinstance(content, tuple):
                     full_path.write_text(yaml.safe_dump_all(content))
                 else:
                     full_path.write_text(yaml.safe_dump(content))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -86,6 +86,8 @@ def create_files(path: Union[str, Path], *contents: dict[str, Any]) -> None:
                     full_path.write_text(content)
                 elif isinstance(content, bytes):
                     full_path.write_bytes(content)
+                elif isinstance(content, list):
+                    full_path.write_text(yaml.safe_dump_all(content))
                 else:
                     full_path.write_text(yaml.safe_dump(content))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from operator_repo import Bundle, Repo
-from tests import bundle_files, create_files
+from tests import bundle_files, catalog_files, create_files
 
 
 @pytest.fixture
@@ -29,6 +29,8 @@ def mock_repo(tmp_path: Path) -> Repo:
         bundle_files("hello", "0.0.2"),
         bundle_files("world", "0.0.1"),
         bundle_files("world", "0.0.2"),
+        catalog_files("v4.17", "hello"),
+        catalog_files("v4.18", "hello"),
     )
     repo = Repo(tmp_path)
     return repo

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -82,7 +82,9 @@ def test_bundle_invalid(tmp_path: Path) -> None:
         },
         bundle_files("invalid_metadata_contents", "0.0.1"),
         {
-            "operators/invalid_metadata_contents/0.0.1/metadata/annotations.yaml": [],
+            "operators/invalid_metadata_contents/0.0.1/metadata/annotations.yaml": [
+                "invalid"
+            ],
         },
         bundle_files("empty_metadata", "0.0.1"),
         {

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -82,9 +82,7 @@ def test_bundle_invalid(tmp_path: Path) -> None:
         },
         bundle_files("invalid_metadata_contents", "0.0.1"),
         {
-            "operators/invalid_metadata_contents/0.0.1/metadata/annotations.yaml": [
-                "invalid"
-            ],
+            "operators/invalid_metadata_contents/0.0.1/metadata/annotations.yaml": [],
         },
         bundle_files("empty_metadata", "0.0.1"),
         {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,8 @@ def test_cli_list(mock_repo: Repo, capsys: CaptureFixture[str]) -> None:
     captured = capsys.readouterr()
     assert "hello/0.0.1" in captured.out
     assert "hello/0.0.2" in captured.out
+    assert "v4.17/hello" in captured.out
+    assert "v4.18/hello" in captured.out
 
 
 def test_cli_list_repo(mock_repo: Repo, capsys: CaptureFixture[str]) -> None:

--- a/tests/test_operator_catalog.py
+++ b/tests/test_operator_catalog.py
@@ -30,7 +30,7 @@ def test_operator_catalog(tmp_path: Path) -> None:
     assert len(list(catalog.all_operator_catalogs())) == 1
     operator_catalog = catalog.operator_catalog("fake-operator")
 
-    assert repr(operator_catalog) == "OperatorCatalog(fake-operator)"
+    assert repr(operator_catalog) == "OperatorCatalog(v4.14/fake-operator)"
 
     assert operator_catalog.repo == repo
     assert operator_catalog.catalog == catalog
@@ -38,6 +38,8 @@ def test_operator_catalog(tmp_path: Path) -> None:
     assert (
         operator_catalog.catalog_content_path == operator_catalog.root / "catalog.yaml"
     )
+
+    assert operator_catalog.catalog_content == [{"foo": "bar"}]
 
     assert operator_catalog == catalog.operator_catalog("fake-operator")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,7 +40,7 @@ def test_load_yaml_invalid(tmp_path: Path) -> None:
 def test_load_multidoc_yaml(tmp_path: Path) -> None:
     create_files(
         tmp_path,
-        {"data/all.yml": [{"hello": "world"}, {"ciao": "mondo"}]},
+        {"data/all.yml": ({"hello": "world"}, {"ciao": "mondo"})},
     )
     assert load_multidoc_yaml(tmp_path / "data/all.yaml") == [
         {"hello": "world"},

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from operator_repo.exceptions import OperatorRepoException
-from operator_repo.utils import load_yaml, lookup_dict
+from operator_repo.utils import load_multidoc_yaml, load_yaml, lookup_dict
 from tests import create_files
 
 
@@ -35,6 +35,28 @@ def test_load_yaml_invalid(tmp_path: Path) -> None:
         _ = load_yaml(tmp_path / "data/multi-doc.yml")
     with pytest.raises(OperatorRepoException, match="is not a valid yaml document"):
         _ = load_yaml(tmp_path / "data/invalid.yml")
+
+
+def test_load_multidoc_yaml(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        {"data/all.yml": [{"hello": "world"}, {"ciao": "mondo"}]},
+    )
+    assert load_multidoc_yaml(tmp_path / "data/all.yaml") == [
+        {"hello": "world"},
+        {"ciao": "mondo"},
+    ]
+    with pytest.raises(FileNotFoundError):
+        _ = load_multidoc_yaml(tmp_path / "data/something.yaml")
+
+
+def test_load_multidoc_yaml_invalid(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        {"data/invalid.yaml": "{This is not a valid\nyaml document]\n"},
+    )
+    with pytest.raises(OperatorRepoException, match="is not a valid yaml document"):
+        _ = load_multidoc_yaml(tmp_path / "data/invalid.yml")
 
 
 def test_lookup_dict() -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = autoflake, isort, black, pylint, mypy, bandit, py{39,310,311,312,py39}
+envlist = test, autoflake, isort, black, pylint, mypy, bandit, py{39,310,311,312,py39}
 isolated_build = True
 
 [gh-actions]
@@ -9,7 +9,7 @@ python =
     3.11: py311
     3.12: py312
 
-[testenv]
+[testenv:test]
 groups =
     test
 commands =


### PR DESCRIPTION
This PR enables to retrieve catalog for operator if exist.
Couple of cosmetic changes to the CLI tool like listing the catalogs for given operator and using catalog version in OperatorCatalog `__repr__` .