### PR TITLE
[ISV-5446] enable and support file based catalog test suite

### DIFF
--- a/src/operator_repo/__init__.py
+++ b/src/operator_repo/__init__.py
@@ -1,3 +1,10 @@
-from .core import Bundle, Catalog, Operator, OperatorCatalog, Repo
+from .core import Bundle, Catalog, Operator, OperatorCatalog, OperatorCatalogList, Repo
 
-__all__ = ["Repo", "Operator", "Bundle", "Catalog", "OperatorCatalog"]
+__all__ = [
+    "Repo",
+    "Operator",
+    "Bundle",
+    "Catalog",
+    "OperatorCatalog",
+    "OperatorCatalogList",
+]

--- a/src/operator_repo/checks/__init__.py
+++ b/src/operator_repo/checks/__init__.py
@@ -81,7 +81,7 @@ class Fail(CheckResult):
 
 SUPPORTED_TYPES = [
     ("operator", Operator),
-    ("fbc", OperatorCatalogList),
+    ("catalog", OperatorCatalogList),
     ("bundle", Bundle),
 ]
 Check = Callable[

--- a/src/operator_repo/checks/__init__.py
+++ b/src/operator_repo/checks/__init__.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterable
 from inspect import getmembers, isfunction
 from typing import Any, List, Optional, Union
 
-from .. import Bundle, Operator, Repo
+from .. import Bundle, Operator, OperatorCatalogList, Repo
 
 log = logging.getLogger(__name__)
 
@@ -79,8 +79,14 @@ class Fail(CheckResult):
     kind = "failure"
 
 
-SUPPORTED_TYPES = [("operator", Operator), ("bundle", Bundle)]
-Check = Callable[[Union[Repo, Operator, Bundle]], Iterable[CheckResult]]
+SUPPORTED_TYPES = [
+    ("operator", Operator),
+    ("fbc", OperatorCatalogList),
+    ("bundle", Bundle),
+]
+Check = Callable[
+    [Union[Repo, Operator, OperatorCatalogList, Bundle]], Iterable[CheckResult]
+]
 
 
 def get_checks(

--- a/src/operator_repo/checks/catalog.py
+++ b/src/operator_repo/checks/catalog.py
@@ -1,0 +1,54 @@
+from collections.abc import Iterator
+
+from .. import OperatorCatalog, OperatorCatalogList
+from . import CheckResult, Fail
+
+
+def _get_bundle_registries_from_catalog(catalog: OperatorCatalog) -> list[str]:
+    """Get bundle images from catalog"""
+    catalog_content = catalog.catalog_content
+    bundle_images = []
+    for item in catalog_content:
+        if isinstance(item, dict):
+            if item.get("schema") == "olm.bundle":
+                if image := item.get("image"):
+                    bundle_images.append(image)
+
+    return bundle_images
+
+
+def _filter_invalid_images(
+    bundle_images: list[str], allowed_registries: list[str]
+) -> list[str]:
+    """Filter out invalid images"""
+    invalid_images = []
+    for image in bundle_images:
+        if not any(image.startswith(registry) for registry in allowed_registries):
+            invalid_images.append(image)
+
+    return invalid_images
+
+
+def check_bundle_images_in_fbc(
+    operator_catalogs: OperatorCatalogList,
+) -> Iterator[CheckResult]:
+    """Validate if bundle image reference in fbc is in allowed registry"""
+
+    allowed_registries = None
+    for catalog in operator_catalogs:
+        try:
+            if not isinstance(allowed_registries, list):
+                # get config only once
+                allowed_registries = catalog.repo.config.get("allowed_registries", [])
+            if not allowed_registries:
+                # nothing to check if no registry restriction is defined
+                break
+            bundle_images = _get_bundle_registries_from_catalog(catalog)
+            invalid_images = _filter_invalid_images(bundle_images, allowed_registries)
+            if invalid_images:
+                yield Fail(
+                    f"Invalid bundle image(s) found in catalog {str(catalog)}: "
+                    f"{', '.join(invalid_images)}"
+                )
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            yield Fail(str(exc))

--- a/src/operator_repo/checks/catalog.py
+++ b/src/operator_repo/checks/catalog.py
@@ -36,19 +36,16 @@ def check_bundle_images_in_fbc(
 
     allowed_registries = None
     for catalog in operator_catalogs:
-        try:
-            if not isinstance(allowed_registries, list):
-                # get config only once
-                allowed_registries = catalog.repo.config.get("allowed_registries", [])
-            if not allowed_registries:
-                # nothing to check if no registry restriction is defined
-                break
-            bundle_images = _get_bundle_registries_from_catalog(catalog)
-            invalid_images = _filter_invalid_images(bundle_images, allowed_registries)
-            if invalid_images:
-                yield Fail(
-                    f"Invalid bundle image(s) found in catalog {str(catalog)}: "
-                    f"{', '.join(invalid_images)}"
-                )
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            yield Fail(str(exc))
+        if not isinstance(allowed_registries, list):
+            # get config only once
+            allowed_registries = catalog.repo.config.get("allowed_registries", [])
+        if not allowed_registries:
+            # nothing to check if no registry restriction is defined
+            break
+        bundle_images = _get_bundle_registries_from_catalog(catalog)
+        invalid_images = _filter_invalid_images(bundle_images, allowed_registries)
+        if invalid_images:
+            yield Fail(
+                f"Invalid bundle image(s) found in {str(catalog)}: "
+                f"{', '.join(invalid_images)}"
+            )

--- a/src/operator_repo/core.py
+++ b/src/operator_repo/core.py
@@ -625,7 +625,7 @@ class OperatorCatalogList(list[OperatorCatalog]):
     A list of operator catalogs
     """
 
-    def __init__(self, operator_catalogs: list[OperatorCatalog] | None = None):
+    def __init__(self, operator_catalogs: Optional[list[OperatorCatalog]] = None):
         if operator_catalogs is None:
             operator_catalogs = []
         if any(not isinstance(item, OperatorCatalog) for item in operator_catalogs):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -100,10 +100,36 @@ def catalog_files(
     catalog_name: str,
     operator: str,
     other_files: Optional[dict[str, Any]] = None,
-    content: Any = None,
+    content: Optional[tuple[Any, ...]] = None,
 ) -> dict[str, Any]:
+    """
+    Create a catalog file as a multi-document yaml file.
+
+    Args:
+        catalog_name (str): The name of the catalog.
+        operator (str): The name of the operator.
+        other_files (dict, optional): Additional files to be created.
+            Defaults to None.
+        content (tuple, optional): The content of the catalog.yaml file.
+            Needs to be a tuple, as the create_files() expects a tuple
+            to create multi-document yaml file. Defaults to example catalog
+            content.
+
+    Returns:
+        dict: A dictionary representing the catalog files, merged with other files.
+    """
+    default_content = (
+        {"defaultChannel": "stable", "name": operator, "schema": "olm.package"},
+        {"name": "alpha", "package": operator, "schema": "olm.channel"},
+        {
+            "name": f"{operator}.v1.0.0",
+            "package": operator,
+            "image": f"quay.io/org/{operator}@sha256:123",
+            "schema": "olm.bundle",
+        },
+    )
     operator_path = f"catalogs/{catalog_name}/{operator}"
-    catalog_content = content or {"foo": "bar"}
+    catalog_content = content or default_content
     return merge(
         {
             f"{operator_path}/catalog.yaml": catalog_content,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -97,13 +97,16 @@ def create_files(path: Union[str, Path], *contents: dict[str, Any]) -> None:
 
 
 def catalog_files(
-    catalog_name: str, operator: str, other_files: Optional[dict[str, Any]] = None
+    catalog_name: str,
+    operator: str,
+    other_files: Optional[dict[str, Any]] = None,
+    content: Any = None,
 ) -> dict[str, Any]:
     operator_path = f"catalogs/{catalog_name}/{operator}"
-
+    catalog_content = content or {"foo": "bar"}
     return merge(
         {
-            f"{operator_path}/catalog.yaml": {"foo": "bar"},
+            f"{operator_path}/catalog.yaml": catalog_content,
         },
         other_files or {},
     )

--- a/tests/checks/test_catalog.py
+++ b/tests/checks/test_catalog.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from operator_repo import OperatorCatalogList, Repo
+from operator_repo.checks.catalog import check_bundle_images_in_fbc
+from tests import bundle_files, catalog_files, create_files
+
+
+@pytest.mark.parametrize(
+    ["config", "expected_results"],
+    [
+        (
+            {},
+            set(),
+        ),
+        (
+            {
+                "allowed_registries": ["quay.io/org-foo/", "quay.io/org-bar/"],
+            },
+            set(),
+        ),
+        (
+            {
+                "allowed_registries": ["quay.io/org-foo/"],
+            },
+            {
+                "Invalid bundle image(s) found in OperatorCatalog(v4.14/fake-operator)"
+                ": quay.io/org-bar/registry/bundle@sha256:123"
+            },
+        ),
+    ],
+    ids=[
+        "Config not set",
+        "All registries allowed",
+        "Registry not allowed",
+    ],
+)
+def test_check_bundle_images_in_fbc(
+    tmp_path: Path,
+    config: dict[str, Any],
+    expected_results: set[str],
+) -> None:
+    catalog_content = (
+        {
+            "schema": "olm.bundle",
+            "image": "quay.io/org-foo/registry/bundle@sha256:123",
+        },
+        {
+            "schema": "olm.bundle",
+            "image": "quay.io/org-bar/registry/bundle@sha256:123",
+        },
+    )
+    create_files(
+        tmp_path,
+        catalog_files("v4.14", "fake-operator", content=catalog_content),
+        bundle_files("fake-operator", "0.0.1"),
+        {"config.yaml": config},
+    )
+    repo = Repo(tmp_path)
+    catalog = repo.catalog("v4.14")
+    operator_catalog = catalog.operator_catalog("fake-operator")
+    catalogs = OperatorCatalogList([operator_catalog])
+    assert {x.reason for x in check_bundle_images_in_fbc(catalogs)} == expected_results

--- a/tests/checks/test_checks.py
+++ b/tests/checks/test_checks.py
@@ -32,7 +32,7 @@ def test_get_checks(mock_import_module: MagicMock) -> None:
     assert get_checks("suite.name") == {
         "operator": [check_fake],
         "bundle": [check_fake],
-        "fbc": [check_fake],
+        "catalog": [check_fake],
     }
     mock_import_module.assert_has_calls(
         [call("suite.name.operator"), call("suite.name.bundle")], any_order=True
@@ -51,7 +51,7 @@ def test_get_checks_skip_check(mock_import_module: MagicMock) -> None:
     assert get_checks("suite.name", skip_tests=["check_ignore"]) == {
         "operator": [check_fake],
         "bundle": [check_fake],
-        "fbc": [check_fake],
+        "catalog": [check_fake],
     }
     mock_import_module.assert_has_calls(
         [call("suite.name.operator"), call("suite.name.bundle")], any_order=True
@@ -64,7 +64,7 @@ def test_get_checks_missing_modules(mock_import_module: MagicMock) -> None:
     assert get_checks("suite.name") == {
         "operator": [],
         "bundle": [],
-        "fbc": [],
+        "catalog": [],
     }
     mock_import_module.assert_has_calls(
         [call("suite.name.operator"), call("suite.name.bundle")], any_order=True

--- a/tests/checks/test_checks.py
+++ b/tests/checks/test_checks.py
@@ -32,6 +32,7 @@ def test_get_checks(mock_import_module: MagicMock) -> None:
     assert get_checks("suite.name") == {
         "operator": [check_fake],
         "bundle": [check_fake],
+        "fbc": [check_fake],
     }
     mock_import_module.assert_has_calls(
         [call("suite.name.operator"), call("suite.name.bundle")], any_order=True
@@ -50,6 +51,7 @@ def test_get_checks_skip_check(mock_import_module: MagicMock) -> None:
     assert get_checks("suite.name", skip_tests=["check_ignore"]) == {
         "operator": [check_fake],
         "bundle": [check_fake],
+        "fbc": [check_fake],
     }
     mock_import_module.assert_has_calls(
         [call("suite.name.operator"), call("suite.name.bundle")], any_order=True
@@ -62,6 +64,7 @@ def test_get_checks_missing_modules(mock_import_module: MagicMock) -> None:
     assert get_checks("suite.name") == {
         "operator": [],
         "bundle": [],
+        "fbc": [],
     }
     mock_import_module.assert_has_calls(
         [call("suite.name.operator"), call("suite.name.bundle")], any_order=True

--- a/tests/test_operator_catalog.py
+++ b/tests/test_operator_catalog.py
@@ -21,7 +21,7 @@ def test_invalid_catalog(tmp_path: Path) -> None:
 def test_operator_catalog(tmp_path: Path) -> None:
     create_files(
         tmp_path,
-        catalog_files("v4.14", "fake-operator"),
+        catalog_files("v4.14", "fake-operator", content=({"foo": "bar"},)),
         catalog_files("v4.13", "fake-operator-2"),
         bundle_files("fake-operator", "0.0.1"),
     )

--- a/tests/test_operator_catalog.py
+++ b/tests/test_operator_catalog.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from operator_repo import OperatorCatalog, Repo
+from operator_repo import OperatorCatalog, OperatorCatalogList, Repo
 from operator_repo.exceptions import InvalidOperatorCatalogException
 from tests import bundle_files, catalog_files, create_files
 
@@ -31,6 +31,7 @@ def test_operator_catalog(tmp_path: Path) -> None:
     operator_catalog = catalog.operator_catalog("fake-operator")
 
     assert repr(operator_catalog) == "OperatorCatalog(v4.14/fake-operator)"
+    assert operator_catalog == "v4.14/fake-operator"
 
     assert operator_catalog.repo == repo
     assert operator_catalog.catalog == catalog
@@ -68,5 +69,51 @@ def test_catalog_operator_compare(tmp_path: Path) -> None:
     assert operator1 < operator2
 
     assert operator1 != "foo"
+    assert operator1 != 42
     with pytest.raises(TypeError):
         operator1 < "foo"
+
+
+def test_operator_catalog_list(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        catalog_files("v4.14", "fake-operator"),
+        catalog_files("v4.14", "fake-operator-2"),
+        catalog_files("v4.14", "fake-operator-3"),
+        catalog_files("v4.14", "fake-operator-4"),
+        bundle_files("fake-operator", "0.0.1"),
+    )
+    repo = Repo(tmp_path)
+    catalog = repo.catalog("v4.14")
+    operator_catalog = catalog.operator_catalog("fake-operator")
+    operator_catalog2 = catalog.operator_catalog("fake-operator-2")
+    operator_catalog3 = catalog.operator_catalog("fake-operator-3")
+    operator_catalog4 = catalog.operator_catalog("fake-operator-4")
+
+    empty_operator_catalog_list = OperatorCatalogList()
+    assert len(empty_operator_catalog_list) == 0
+    operator_catalog_list = OperatorCatalogList([operator_catalog, operator_catalog])
+    assert len(operator_catalog_list) == 1
+    assert repr(operator_catalog_list) == "[OperatorCatalog(v4.14/fake-operator)]"
+    operator_catalog_list.append(operator_catalog2)
+    operator_catalog_list.extend([operator_catalog3])
+    operator_catalog_list.insert(0, operator_catalog4)
+    assert len(operator_catalog_list) == 4
+
+    assert operator_catalog in operator_catalog_list
+    assert "v4.14/fake-operator-4" in operator_catalog_list
+
+    with pytest.raises(ValueError):
+        operator_catalog_list.append(operator_catalog)
+    with pytest.raises(ValueError):
+        operator_catalog_list.insert(0, operator_catalog)
+    with pytest.raises(ValueError):
+        operator_catalog_list.extend([operator_catalog])
+    with pytest.raises(TypeError):
+        OperatorCatalogList(["foo", 1])  # type: ignore
+    with pytest.raises(TypeError):
+        operator_catalog_list.append("foo")
+    with pytest.raises(TypeError):
+        operator_catalog_list.extend([1, 2, 3])
+    with pytest.raises(TypeError):
+        operator_catalog_list.insert(0, {"foo": "bar"})

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = test, autoflake, isort, black, pylint, mypy, bandit, py{39,310,311,312,py39}
+envlist = autoflake, isort, black, pylint, mypy, bandit, py{39,310,311,312,py39}
 isolated_build = True
 
 [gh-actions]
@@ -9,7 +9,7 @@ python =
     3.11: py311
     3.12: py312
 
-[testenv:test]
+[testenv]
 groups =
     test
 commands =


### PR DESCRIPTION
This PR is adding new data-class to store OperatorCatalogs and extends checks with new `fbc` module.