### PR TITLE
Ensure valid operator_catalog_name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "operator-repo"
-version = "0.4.8"
+version = "0.4.9"
 description = "Library and utilities to handle repositories of kubernetes operators"
 authors = [
     {name = "Maurizio Porrato", email = "mporrato@redhat.com"},

--- a/src/operator_repo/core.py
+++ b/src/operator_repo/core.py
@@ -564,9 +564,7 @@ class OperatorCatalog:
         :return: The operator catalog name combining the catalog name
             and the operator name eg.: 'v4.12/operator-x'
         """
-        return (
-            self._parent.catalog_name + "/" if self._parent else ""
-        ) + self.operator_name
+        return self.catalog.catalog_name + "/" + self.operator_name
 
     @property
     def catalog_content_path(

--- a/tests/test_operator_catalog.py
+++ b/tests/test_operator_catalog.py
@@ -33,6 +33,11 @@ def test_operator_catalog(tmp_path: Path) -> None:
     assert repr(operator_catalog) == "OperatorCatalog(v4.14/fake-operator)"
     assert operator_catalog == "v4.14/fake-operator"
 
+    # create operator catalog directly without Catalog
+    catalog_without_parent = OperatorCatalog(repo.catalog_path("v4.14/fake-operator"))
+    assert catalog_without_parent == operator_catalog
+    assert catalog_without_parent.operator_catalog_name == "v4.14/fake-operator"
+
     assert operator_catalog.repo == repo
     assert operator_catalog.catalog == catalog
 


### PR DESCRIPTION
Fix issue with `operator_catalog_name` when OperatorCatalog was created from Repo directly, without Catalog.