### PR TITLE
[ISV-4783] Add support for `skipRange` CSV field.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "operator-repo"
-version = "0.4.9"
+version = "0.4.10"
 description = "Library and utilities to handle repositories of kubernetes operators"
 authors = [
     {name = "Maurizio Porrato", email = "mporrato@redhat.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 dependencies = [
     "pyyaml>=6.0.1",
-    "semver>=3.0.1",
+    "semantic-version>=2.10.0",
 ]
 requires-python = ">=3.9"
 readme = "README.md"

--- a/src/operator_repo/checks/bundle.py
+++ b/src/operator_repo/checks/bundle.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterator
 
-from semver import Version
+from semantic_version import Version
 
 from .. import Bundle
 from ..utils import lookup_dict

--- a/src/operator_repo/checks/bundle.py
+++ b/src/operator_repo/checks/bundle.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterator
 
-from semantic_version import Version
+from semantic_version import Version  # type: ignore
 
 from .. import Bundle
 from ..utils import lookup_dict
@@ -104,13 +104,13 @@ def check_image(bundle: Bundle) -> Iterator[CheckResult]:
 def check_semver(bundle: Bundle) -> Iterator[CheckResult]:
     """Check that the bundle version is semver compliant"""
     try:
-        _ = Version.parse(bundle.operator_version)
+        _ = Version(bundle.operator_version)
     except ValueError:
         yield Warn(
             f"Version from filesystem ({bundle.operator_version}) is not valid semver"
         )
     try:
-        _ = Version.parse(bundle.csv_operator_version)
+        _ = Version(bundle.csv_operator_version)
     except ValueError:
         yield Warn(
             f"Version from CSV ({bundle.csv_operator_version}) is not valid semver"

--- a/src/operator_repo/core.py
+++ b/src/operator_repo/core.py
@@ -9,7 +9,7 @@ from functools import cached_property, total_ordering
 from pathlib import Path
 from typing import Any, Optional, SupportsIndex, Union
 
-from semantic_version import NpmSpec, Version
+from semantic_version import NpmSpec, Version  # type: ignore
 
 from .exceptions import (
     InvalidBundleException,
@@ -204,9 +204,9 @@ class Bundle:
         if self.csv_operator_name != other.csv_operator_name:
             return False
         try:
-            return Version.parse(
+            return Version(  # type: ignore
                 self.csv_operator_version.lstrip("v")
-            ) == Version.parse(other.csv_operator_version.lstrip("v"))
+            ) == Version(other.csv_operator_version.lstrip("v"))
         except ValueError:
             log.warning(
                 "Can't compare bundle versions %s and %s as semver: using lexical order instead",
@@ -227,7 +227,7 @@ class Bundle:
         if self.csv_operator_name != other.csv_operator_name:
             return self.csv_operator_name < other.csv_operator_name
         try:
-            return Version.parse(self.csv_operator_version.lstrip("v")) < Version.parse(
+            return Version(self.csv_operator_version.lstrip("v")) < Version(  # type: ignore
                 other.csv_operator_version.lstrip("v")
             )
         except ValueError:
@@ -382,7 +382,7 @@ class Operator:
         try:
             version_channel_pairs: list[tuple[Union[str, Version], str]] = [
                 (
-                    Version.parse(x.csv_operator_version),
+                    Version(x.csv_operator_version),
                     x.default_channel,
                 )
                 for x in self.all_bundles()

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -99,6 +99,11 @@ def test_update_graph(tmp_path: Path) -> None:
             "0.0.4",
             csv={"spec": {"replaces": "hello.v0.0.2", "skips": ["hello.v0.0.3"]}},
         ),
+        bundle_files(
+            "hello",
+            "0.0.5",
+            csv={"spec": {"skipRange": ">=0.0.3 <0.0.5", "replaces": "hello.v0.0.2"}},
+        ),
     )
     repo = Repo(tmp_path)
     operator = repo.operator("hello")
@@ -106,11 +111,13 @@ def test_update_graph(tmp_path: Path) -> None:
     bundle2 = operator.bundle("0.0.2")
     bundle3 = operator.bundle("0.0.3")
     bundle4 = operator.bundle("0.0.4")
-    assert operator.head("beta") == bundle4
+    bundle5 = operator.bundle("0.0.5")
+    assert operator.head("beta") == bundle5
     update = operator.update_graph("beta")
     assert update[bundle1] == {bundle2}
-    assert update[bundle2] == {bundle3, bundle4}
-    assert update[bundle3] == {bundle4}
+    assert update[bundle2] == {bundle3, bundle4, bundle5}
+    assert update[bundle3] == {bundle4, bundle5}
+    assert update[bundle4] == {bundle5}
 
 
 def test_update_graph_invalid_replaces(tmp_path: Path) -> None:

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -102,7 +103,10 @@ def test_update_graph(tmp_path: Path) -> None:
         bundle_files(
             "hello",
             "0.0.5",
-            csv={"spec": {"skipRange": ">=0.0.3 <0.0.5", "replaces": "hello.v0.0.2"}},
+            csv={
+                "spec": {"replaces": "hello.v0.0.2"},
+                "metadata": {"annotations": {"olm.skipRange": ">=0.0.3 <0.0.5"}},
+            },
         ),
     )
     repo = Repo(tmp_path)
@@ -118,6 +122,32 @@ def test_update_graph(tmp_path: Path) -> None:
     assert update[bundle2] == {bundle3, bundle4, bundle5}
     assert update[bundle3] == {bundle4, bundle5}
     assert update[bundle4] == {bundle5}
+
+
+@patch("operator_repo.core.log")
+def test_update_graph_invalid_skip_range(mock_log: MagicMock, tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        bundle_files("hello", "0.0.1"),
+        bundle_files(
+            "hello",
+            "0.0.2",
+            # Range cannot contain the letter 'v', raises ValueError
+            csv={
+                "spec": {"replaces": "hello.v0.0.1"},
+                "metadata": {"annotations": {"olm.skipRange": "<v0.0.2"}},
+            },
+        ),
+    )
+    repo = Repo(tmp_path)
+    operator = repo.operator("hello")
+    bundle1 = operator.bundle("0.0.1")
+    bundle2 = operator.bundle("0.0.2")
+    assert operator.head("beta") == bundle2
+    update = operator.update_graph("beta")
+    # Field 'replaces' works and the code does not fail, but a warning is logged
+    mock_log.warning.assert_called()
+    assert update[bundle1] == {bundle2}
 
 
 def test_update_graph_invalid_replaces(tmp_path: Path) -> None:

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 


### PR DESCRIPTION
This task required to change the `semver` package to `semantic-versioning` because [`semver` does not support ranges](https://github.com/python-semver/python-semver/issues/241), whereas [`semantic-versioning` does](https://github.com/rbarrois/python-semanticversion?tab=readme-ov-file#requirement-specification).