### PR TITLE
Add release_config property to Bundle class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "operator-repo"
-version = "0.4.10"
+version = "0.4.11"
 description = "Library and utilities to handle repositories of kubernetes operators"
 authors = [
     {name = "Maurizio Porrato", email = "mporrato@redhat.com"},

--- a/src/operator_repo/core.py
+++ b/src/operator_repo/core.py
@@ -70,6 +70,16 @@ class Bundle:
             raise InvalidBundleException(f"Invalid CSV contents ({self.csv_file_name})")
         return csv
 
+    @cached_property
+    def release_config(self) -> Any:
+        """
+        :return: The content of the "release-config.yaml" file in the bundle directory
+        """
+        path = self._bundle_path / "release-config.yaml"
+        if not path.is_file():
+            return None
+        return load_yaml(path)
+
     @property
     def metadata_operator_name(self) -> str:
         """
@@ -82,7 +92,7 @@ class Bundle:
     @cached_property
     def csv_full_name(self) -> tuple[str, str]:
         """
-        :return: A tuple containging operator name and bundle version
+        :return: A tuple containing operator name and bundle version
         extracted from the bundle's csv file
         """
         try:

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -23,6 +23,20 @@ def test_bundle(tmp_path: Path) -> None:
         == "hello"
     )
     assert bundle.dependencies == []
+    assert bundle.release_config == None
+
+
+def test_bundle_with_release_config(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        bundle_files("hello", "0.0.1"),
+        {"operators/hello/0.0.1/release-config.yaml": {"catalogs": []}},
+    )
+    repo = Repo(tmp_path)
+    operator = repo.operator("hello")
+    bundle = operator.bundle("0.0.1")
+
+    assert bundle.release_config == {"catalogs": []}
 
 
 def test_bundle_compare(tmp_path: Path) -> None:


### PR DESCRIPTION
The release_config property represents a new release-config.yaml file that stores information about how a bundle should be released in FBC.

JIRA: ISV-5506