### PR TITLE
Return Fail when test crashes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "operator-repo"
-version = "0.4.11"
+version = "0.4.12"
 description = "Library and utilities to handle repositories of kubernetes operators"
 authors = [
     {name = "Maurizio Porrato", email = "mporrato@redhat.com"},

--- a/src/operator_repo/cli.py
+++ b/src/operator_repo/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-    CLI tool to handle operator repositories
+CLI tool to handle operator repositories
 """
 
 import argparse

--- a/src/operator_repo/core.py
+++ b/src/operator_repo/core.py
@@ -1,5 +1,5 @@
 """
-    Definition of Repo, Operator, Bundle, Catalog and CatalogOperator classes
+Definition of Repo, Operator, Bundle, Catalog and CatalogOperator classes
 """
 
 import logging

--- a/src/operator_repo/exceptions.py
+++ b/src/operator_repo/exceptions.py
@@ -1,5 +1,5 @@
 """
-    Exceptions
+Exceptions
 """
 
 

--- a/src/operator_repo/utils.py
+++ b/src/operator_repo/utils.py
@@ -1,5 +1,5 @@
 """
-    Utility functions to load yaml files
+Utility functions to load yaml files
 """
 
 import logging

--- a/tests/checks/test_checks.py
+++ b/tests/checks/test_checks.py
@@ -79,6 +79,20 @@ def test_run_check(mock_bundle: Bundle) -> None:
         Warn("foo", "check_fake", mock_bundle)
     ]
 
+    def check_with_exception(_something):  # type: ignore
+        raise Exception("bar")
+
+    results = list(run_check(check_with_exception, mock_bundle))
+    assert results == [
+        Fail(
+            # Copying the exception message
+            results[0].reason,
+            "check_with_exception",
+            mock_bundle,
+        )
+    ]
+    assert 'Exception("bar")' in results[0].reason
+
 
 @patch("operator_repo.checks.get_checks")
 def test_run_suite(mock_get_checks: MagicMock, mock_bundle: Bundle) -> None:


### PR DESCRIPTION
Instead of crashing a whole test suite the code raises the exception in form of Fail(). The check will be reported as failed to user and user will be able to see the traceback.